### PR TITLE
fix the error message in issue #375

### DIFF
--- a/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
+++ b/typed-racket-lib/typed-racket/base-env/prims-contract.rkt
@@ -342,7 +342,7 @@
             (define existing-ty-ctc (syntax-local-lift-expression
                                      (make-contract-def-rhs/from-typed existing-ty-id #f #f)))
             (define (store-existing-type existing-type)
-              (cast-table-set! existing-ty-id existing-type))
+              (cast-table-set! existing-ty-id (datum->syntax #f existing-type #'v)))
             (define (check-valid-type _)
               (define type (parse-type #'ty))
               (define vars (fv type))


### PR DESCRIPTION
Programs that use `cast` on values with types that can't be converted to contracts currently raise errors about `syntax-source` not receiving a syntax object. This pull request fixes those so that they raise the normal contract generation errors, with the source location of the casted expression.

For example this program

``` racket
#lang typed/racket
(define v (ann (vector 1) VectorTop))
(cast v Any)
```

Currently raises the error

```
. . ../../Applications/Racket/2016-06-16/Racket v6.5.0.5/share/pkgs/source-syntax/source-syntax.rkt:78:2: syntax-source: contract violation
  expected: syntax?
  given: (VectorTop 940 (combined-frees (make-immutable-hasheq) empty) (combined-frees (make-immutable-hasheq) empty) false 'vector)
```

With this pull request, this program fails with the message

```
. Type Checker: Type VectorTop could not be converted to a contract: contract generation not supported for this type in: v
```
