### PR TITLE
add (and/c vector? any-wrap/c) -like contracts

### DIFF
--- a/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -353,7 +353,7 @@
 
       (define (only-untyped sc)
         (if (from-typed? typed-side)
-            (fail #:reason "contract generation not supported for this type")
+            (and/sc sc any-wrap/sc)
             sc))
       (cached-match sc-cache type typed-side
         ;; Applications of implicit recursive type aliases


### PR DESCRIPTION
For `VectorTop`, `HashTableTop`, etc. going from typed to untyped.

This fixes examples like

``` racket
#lang typed/racket
(define v (ann (vector 1) VectorTop))
(cast v Any)
```

To generate `(and/c vector? any-wrap/c)` contracts instead of raising a compile-time contract-generation error. This reduces some of the backwards-incompatibility from the `cast` soundness fix.

This fixes some of the problems in https://github.com/racket/typed-racket/issues/375, although both `measures-with-dimensions` and `wrap` are still failing for other reasons.
